### PR TITLE
Use KMS Key ID as the primary key, instead of the 'JWT' + KID

### DIFF
--- a/packages/handlers/jwks/test/index.test.ts
+++ b/packages/handlers/jwks/test/index.test.ts
@@ -5,7 +5,7 @@ import { handler } from '../src/index';
 import { Context } from 'aws-lambda';
 import {
     DynamoDBClient,
-    ScanCommand,
+    GetItemCommand,
     PutItemCommand,
 } from '@aws-sdk/client-dynamodb';
 import {
@@ -25,14 +25,14 @@ describe('jwks.json Tests', () => {
     it('Found JWK, TTL > 10 days', async () => {
         const entry = data.jwksValidEntry(30);
 
-        ddbMock.on(ScanCommand).resolves(entry);
+        ddbMock.on(GetItemCommand).resolves(entry);
 
         const response = await handler(data.jwksEventRequest, {} as Context, (error, result) => {/* do nothing */ });
-        expect(ddbMock).toHaveReceivedCommandTimes(ScanCommand, 1);
+        expect(ddbMock).toHaveReceivedCommandTimes(GetItemCommand, 1);
         expect(kmsMock).toHaveReceivedCommandTimes(PutItemCommand, 0);
         expect(kmsMock).toHaveReceivedCommandTimes(GetPublicKeyCommand, 0);
         expect(response?.statusCode).toBe(200);
-        expect(JSON.parse(response?.body!).keys[0].kid).toBe(entry.Items![0]['kid']['S']);
+        expect(JSON.parse(response?.body!).keys[0].kid).toBe(entry.Item!['kid']['S']);
     });
 
     it('Found JWK, TTL < 10 days', async () => {
@@ -40,31 +40,31 @@ describe('jwks.json Tests', () => {
         const refreshEntry = data.jwksRefreshEntry(30);
 
         ddbMock
-            .on(ScanCommand).resolvesOnce(entry).resolves(refreshEntry)
+            .on(GetItemCommand).resolvesOnce(entry).resolves(refreshEntry)
             .on(PutItemCommand).resolves(data.jwksPutItem);
         kmsMock.on(GetPublicKeyCommand).resolves(data.jwksGetPublicKey);
 
         const response = await handler(data.jwksEventRequest, {} as Context, (error, result) => {/* do nothing */ });
-        expect(ddbMock).toHaveReceivedCommandTimes(ScanCommand, 2);
+        expect(ddbMock).toHaveReceivedCommandTimes(GetItemCommand, 2);
         expect(ddbMock).toHaveReceivedCommandTimes(PutItemCommand, 1);
         expect(kmsMock).toHaveReceivedCommandTimes(GetPublicKeyCommand, 1);
         expect(response?.statusCode).toBe(200);
-        expect(JSON.parse(response?.body!).keys[0].kid).toBe(refreshEntry.Items![0]['kid']['S']);
+        expect(JSON.parse(response?.body!).keys[0].kid).toBe(refreshEntry.Item!['kid']['S']);
     });
 
     it('Not found JWK', async () => {
         const refreshEntry = data.jwksRefreshEntry(30);
 
         ddbMock
-            .on(ScanCommand).resolvesOnce(data.jwksEmptyEntry).resolves(refreshEntry)
+            .on(GetItemCommand).resolvesOnce(data.jwksEmptyEntry).resolves(refreshEntry)
             .on(PutItemCommand).resolves(data.jwksPutItem);
         kmsMock.on(GetPublicKeyCommand).resolves(data.jwksGetPublicKey);
 
         const response = await handler(data.jwksEventRequest, {} as Context, (error, result) => {/* do nothing */ });
-        expect(ddbMock).toHaveReceivedCommandTimes(ScanCommand, 2);
+        expect(ddbMock).toHaveReceivedCommandTimes(GetItemCommand, 2);
         expect(ddbMock).toHaveReceivedCommandTimes(PutItemCommand, 1);
         expect(kmsMock).toHaveReceivedCommandTimes(GetPublicKeyCommand, 1);
         expect(response?.statusCode).toBe(200);
-        expect(JSON.parse(response?.body!).keys[0].kid).toBe(refreshEntry.Items![0]['kid']['S']);
+        expect(JSON.parse(response?.body!).keys[0].kid).toBe(refreshEntry.Item!['kid']['S']);
     });
 });

--- a/test/utils/data.ts
+++ b/test/utils/data.ts
@@ -1,5 +1,5 @@
 import { APIGatewayProxyEvent } from 'aws-lambda';
-import { ScanCommandOutput, PutItemCommandOutput } from '@aws-sdk/client-dynamodb';
+import { PutItemCommandOutput, GetItemCommandOutput } from '@aws-sdk/client-dynamodb';
 import { GetPublicKeyCommandOutput } from "@aws-sdk/client-kms";
 
 export const jwksEventRequest: APIGatewayProxyEvent = {
@@ -49,11 +49,11 @@ export const jwksEventRequest: APIGatewayProxyEvent = {
     'isBase64Encoded': false
 }
 
-export const jwksValidEntry = (days: number = 30): Partial<ScanCommandOutput> => {
+export const jwksValidEntry = (days: number = 30): Partial<GetItemCommandOutput> => {
     return {
-        Items: [{
+        Item: {
             "PK": {
-                "S": "JWK#f2cafabe-8d1b-423c-9082-53201c279a0a"
+                "S": "4c2ff352-324d-4277-916f-b29e51a3707b"
             },
             "kid": {
                 "S": "f2cafabe-8d1b-423c-9082-53201c279a0a"
@@ -67,7 +67,7 @@ export const jwksValidEntry = (days: number = 30): Partial<ScanCommandOutput> =>
             "ttl": {
                 "N": `${(new Date().getTime() / 1000) + 86400 * days}`
             }
-        }]
+        }
     };
 }
 
@@ -96,11 +96,11 @@ export const jwksGetPublicKey: Partial<GetPublicKeyCommandOutput> = {
     ],
 }
 
-export const jwksRefreshEntry = (days: number = 30): Partial<ScanCommandOutput> => {
+export const jwksRefreshEntry = (days: number = 30): Partial<GetItemCommandOutput> => {
     return {
-        Items: [{
+        Item: {
             "PK": {
-                "S": "JWK#a4c976d4-d70e-4e56-9ad3-2b69bde0e907",
+                "S": "4c2ff352-324d-4277-916f-b29e51a3707b",
             },
             "kid": {
                 "S": "a4c976d4-d70e-4e56-9ad3-2b69bde0e907",
@@ -114,13 +114,12 @@ export const jwksRefreshEntry = (days: number = 30): Partial<ScanCommandOutput> 
             "ttl": {
                 "N": `${(new Date().getTime() / 1000) + 86400 * days}`,
             },
-        }]
+        }
     };
 }
 
 export const jwksPutItem: Partial<PutItemCommandOutput> = {
 }
 
-export const jwksEmptyEntry: Partial<ScanCommandOutput> = {
-    Items: []
+export const jwksEmptyEntry: Partial<GetItemCommandOutput> = {
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The code was refactored to use KMS Key ID as PK for KMS key entry in the configuration DDB table. With this change, we are also using `getItem` to query for the key, instead of `scan`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
