### PR TITLE
fix: upgrade mkdocs-material to >=9.5.32

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,5 +19,5 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material 
+      - run: pip install "mkdocs-material>=9.5.32" 
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
Upgrades mkdocs-material dependency to >=9.5.32 which includes security improvements.

No functional changes to documentation content or search functionality.